### PR TITLE
Drop the protocol from the elasticsearch URL proxy config

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ func main() {
 			log.Fatal("Unable to find elastic search service")
 		}
 
-		elasticProxyURL = fmt.Sprintf("http://%s/elasticsearch", appEnv.ApplicationURIs[0])
+		elasticProxyURL = fmt.Sprintf("//%s/elasticsearch", appEnv.ApplicationURIs[0])
 		selfAppID = appEnv.ApplicationID
 	}
 	fmt.Printf("Starting kibana to backend elastic search %s...\n", elasticBackendURL)


### PR DESCRIPTION
Using "//$host:$port" works for both the HTTP and HTTPS concurrently,
depending on what the browser/UA is using.
